### PR TITLE
Tests running

### DIFF
--- a/test/detect_test.sh
+++ b/test/detect_test.sh
@@ -40,5 +40,5 @@ testSetup()
 testMissingAnyVersionFile()
 { 
     detect
-    assertCapturedError 1 ${rtrn}
+    assertCapturedError
 }

--- a/test/detect_test.sh
+++ b/test/detect_test.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+. ${BUILDPACK_TEST_RUNNER_HOME}/lib/test_utils.sh
+
+testDetect()
+{
+  mkdir ${BUILD_DIR}/bin
+  touch ${BUILD_DIR}/bin/detect
+  touch ${BUILD_DIR}/bin/compile
+  touch ${BUILD_DIR}/bin/release
+  mkdir ${BUILD_DIR}/test
+  
+  capture ${BUILDPACK_HOME}/bin/detect ${BUILD_DIR}
+  
+  assertEquals 0 ${rtrn}
+  assertEquals "Buildpack Test" "$(cat ${STD_OUT})"
+  assertEquals "" "$(cat ${STD_ERR})"
+}
+
+testNoDetectMissingBuildpackScripts()
+{
+  mkdir ${BUILD_DIR}/test
+
+  capture ${BUILDPACK_HOME}/bin/detect ${BUILD_DIR}
+ 
+  assertEquals 1 ${rtrn}
+  assertEquals "no" "$(cat ${STD_OUT})"
+  assertEquals "" "$(cat ${STD_ERR})"
+}
+
+testNoDetectMissingTestDir()
+{
+  mkdir ${BUILD_DIR}/bin
+  touch ${BUILD_DIR}/bin/detect
+  touch ${BUILD_DIR}/bin/complie
+  touch ${BUILD_DIR}/bin/release
+
+  capture ${BUILDPACK_HOME}/bin/detect ${BUILD_DIR}
+ 
+  assertEquals 1 ${rtrn}
+  assertEquals "no" "$(cat ${STD_OUT})"
+  assertEquals "" "$(cat ${STD_ERR})"
+}

--- a/test/detect_test.sh
+++ b/test/detect_test.sh
@@ -2,15 +2,10 @@
 
 . ${BUILDPACK_TEST_RUNNER_HOME}/lib/test_utils.sh
 
-testVersion()
-{
-  mkdir ${BUILD_DIR}/bin
-  touch ${BUILD_DIR}/bin/detect
-  touch ${BUILD_DIR}/bin/compile
-  touch ${BUILD_DIR}/bin/release
-  mkdir ${BUILD_DIR}/test
-  
+testDetect()
+{ 
   detect
   assertCapturedSuccess
   assertCaptured "Python"
+  echo ${rtrn}
 }

--- a/test/detect_test.sh
+++ b/test/detect_test.sh
@@ -40,5 +40,5 @@ testSetup()
 testMissingAnyVersionFile()
 { 
     detect
-    assertCapturedError
+    assertEquals 1 ${rtrn}
 }

--- a/test/detect_test.sh
+++ b/test/detect_test.sh
@@ -4,8 +4,41 @@
 
 testDetect()
 { 
-  detect
-  assertCapturedSuccess
-  assertCaptured "Python"
-  echo ${rtrn}
+    touch ${BUILD_DIR}/requirements.txt
+    touch ${BUILD_DIR}/setup.py
+    touch ${BUILD_DIR}/Pipfile
+    detect
+    assertCapturedSuccess
+    assertCaptured "Python"
+}
+
+testRequirements()
+{ 
+    touch ${BUILD_DIR}/requirements.txt
+    detect
+    assertCapturedSuccess
+    assertCaptured "Python"
+}
+
+testPipfile()
+{ 
+    
+    touch ${BUILD_DIR}/Pipfile
+    detect
+    assertCapturedSuccess
+    assertCaptured "Python"
+}
+
+testSetup()
+{ 
+    touch ${BUILD_DIR}/setup.py
+    detect
+    assertCapturedSuccess
+    assertCaptured "Python"
+}
+
+testMissingAnyVersionFile()
+{ 
+    detect
+    assertCapturedError 1 ${rtrn}
 }

--- a/test/detect_test.sh
+++ b/test/detect_test.sh
@@ -2,7 +2,7 @@
 
 . ${BUILDPACK_TEST_RUNNER_HOME}/lib/test_utils.sh
 
-testDetect()
+testVersion()
 {
   mkdir ${BUILD_DIR}/bin
   touch ${BUILD_DIR}/bin/detect
@@ -10,34 +10,7 @@ testDetect()
   touch ${BUILD_DIR}/bin/release
   mkdir ${BUILD_DIR}/test
   
-  capture ${BUILDPACK_HOME}/bin/detect ${BUILD_DIR}
-  
-  assertEquals 0 ${rtrn}
-  assertEquals "Buildpack Test" "$(cat ${STD_OUT})"
-  assertEquals "" "$(cat ${STD_ERR})"
-}
-
-testNoDetectMissingBuildpackScripts()
-{
-  mkdir ${BUILD_DIR}/test
-
-  capture ${BUILDPACK_HOME}/bin/detect ${BUILD_DIR}
- 
-  assertEquals 1 ${rtrn}
-  assertEquals "no" "$(cat ${STD_OUT})"
-  assertEquals "" "$(cat ${STD_ERR})"
-}
-
-testNoDetectMissingTestDir()
-{
-  mkdir ${BUILD_DIR}/bin
-  touch ${BUILD_DIR}/bin/detect
-  touch ${BUILD_DIR}/bin/complie
-  touch ${BUILD_DIR}/bin/release
-
-  capture ${BUILDPACK_HOME}/bin/detect ${BUILD_DIR}
- 
-  assertEquals 1 ${rtrn}
-  assertEquals "no" "$(cat ${STD_OUT})"
-  assertEquals "" "$(cat ${STD_ERR})"
+  detect
+  assertCapturedSuccess
+  assertCaptured "Python"
 }


### PR DESCRIPTION
This is an initial test file for the `detect` bin script. This uses the builtin shutils tools and was created in conjunction with the [heroku-buildpack-testrunner](https://github.com/CaseyFaist/heroku-buildpack-testrunner).

This simple script asserts that the `detect` script exits when no `requirements.txt`, `setup.py` or `pipfile` is found, and succeeds when one or all of the files are present in the build directory. 